### PR TITLE
UX: replace border with text colour on select with keyboard

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -35,20 +35,23 @@
   box-shadow: var(--shadow-card);
   border: 1px solid transparent;
 
-  td:first-child {
-    border: 0 !important;
-  }
-
   &:has(.topic-card__thumbnail) {
     max-height: 210px;
   }
 
-  &:hover {
+  &:hover,
+  &.selected {
     cursor: pointer;
     border: 1px solid var(--primary-low);
 
     .title {
       text-decoration: underline;
+    }
+  }
+
+  &.selected {
+    .title {
+      color: var(--quaternary) !important;
     }
   }
 
@@ -98,7 +101,7 @@
     flex-grow: 1;
     padding: 1rem 1.5rem 1rem 0 !important;
     box-sizing: border-box;
-    border: 0 !important;
+    box-shadow: none !important;
 
     .topic-excerpt {
       display: none; //hide default excerpt from pinned topics
@@ -137,6 +140,9 @@
     }
 
     .topic-card {
+      &.selected {
+        //j-k box shadow reimplement
+      }
       &__category {
         grid-area: category;
       }


### PR DESCRIPTION
The default border on a topic item doesn't work well with rounded corners and a thumbnail in the way, so opting to replace that with highlighting the title instead on keyboard navigation.

<img width="854" alt="image" src="https://github.com/discourse/discourse-topic-cards/assets/101828855/47f9f0b9-bda5-4cce-9c55-5f172db5a602">
