### PR TITLE
Add icons for Views and Replies, and Last Activity date

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -151,7 +151,9 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        .number, .d-icon, .activity a {
+        .number,
+        .d-icon,
+        .activity a {
           font-weight: bold;
           font-size: var(--font-down-1-rem);
         }
@@ -164,6 +166,12 @@
             flex-grow: 0;
             flex-shrink: 1;
             margin-left: 20px; /* Adjust as necessary for spacing */
+            &.topic-card__likes:first-child:last-child {
+              color: var(--love);
+              .d-icon {
+                color: var(--love);
+              }
+            }
           }
         }
       }
@@ -189,7 +197,8 @@
 }
 
 // remove fixed with and heat color from activity column
-.topic-list .age, .topic-list .activity {
+.topic-list .age,
+.topic-list .activity {
   width: inherit;
   a {
     color: inherit;

--- a/common/common.scss
+++ b/common/common.scss
@@ -155,6 +155,21 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+        .number, .d-icon, .activity a {
+          font-weight: bold;
+          font-size: var(--font-down-1-rem);
+        }
+        .right-aligned {
+          margin-left: auto;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          .item {
+            flex-grow: 0;
+            flex-shrink: 1;
+            margin-left: 20px; /* Adjust as necessary for spacing */
+          }
+        }
       }
       &__publish-date {
         font-size: var(--font-down-1-rem);
@@ -173,20 +188,14 @@
         -webkit-box-orient: vertical;
         max-height: 3.3em;
       }
-      &__likes {
-        display: flex;
-        align-items: center;
-        gap: 0.25em;
-        &-number {
-          color: var(--love);
-          font-weight: bold;
-          font-size: var(--font-down-1-rem);
-        }
-
-        .d-icon {
-          color: var(--love);
-        }
-      }
     }
+  }
+}
+
+// remove fixed with and heat color from activity column
+.topic-list .age, .topic-list .activity {
+  width: inherit;
+  a {
+    color: inherit;
   }
 }

--- a/javascripts/discourse/raw-views/topic-metadata.js
+++ b/javascripts/discourse/raw-views/topic-metadata.js
@@ -1,3 +1,10 @@
 import EmberObject from "@ember/object";
 
-export default class extends EmberObject {}
+import discourseComputed from "discourse-common/utils/decorators";
+
+export default EmberObject.extend({
+    @discourseComputed("topic.posts_count")
+    replyCount(postsCount) {
+        return postsCount - 1;
+    }
+});

--- a/javascripts/discourse/raw-views/topic-metadata.js
+++ b/javascripts/discourse/raw-views/topic-metadata.js
@@ -1,10 +1,3 @@
 import EmberObject from "@ember/object";
 
-import discourseComputed from "discourse-common/utils/decorators";
-
-export default EmberObject.extend({
-    @discourseComputed("topic.posts_count")
-    replyCount(postsCount) {
-        return postsCount - 1;
-    }
-});
+export default class extends EmberObject {}

--- a/javascripts/discourse/templates/topic-metadata.hbr
+++ b/javascripts/discourse/templates/topic-metadata.hbr
@@ -1,31 +1,41 @@
 <div class="topic-card__metadata">
-  <span class="topic-card__publish-date">
-    {{theme-i18n "published"}}
-    {{format-date view.topic.createdAt format="medium-with-ago"}}
-  </span>
+  {{#if (theme-setting 'show_publish_date')}}
+    <span class="topic-card__publish-date">
+      {{theme-i18n "published"}}
+      {{format-date view.topic.createdAt format="medium-with-ago"}}
+    </span>
+  {{/if}}
 
   <div class="right-aligned item">
-    <span class="topic-card__views">
-      {{d-icon "eye"}}
-      <span class="number">
-        {{view.topic.views}}
+    {{#if (theme-setting 'show_views')}}
+      <span class="topic-card__views">
+        {{d-icon "eye"}}
+        <span class="number">
+          {{view.topic.views}}
+        </span>
       </span>
-    </span>
+    {{/if}}
 
-    <span class="topic-card__likes item">
-      {{d-icon "heart"}}
-      <span class="number">
-        {{view.topic.like_count}}
+    {{#if (theme-setting 'show_likes')}}
+      <span class="topic-card__likes item">
+        {{d-icon "heart"}}
+        <span class="number">
+          {{view.topic.like_count}}
+        </span>
       </span>
-    </span>
+    {{/if}}
 
-    <span class="topic-card__reply_count item">
-      {{d-icon "comment"}}
-      <span class="number">
-        {{view.topic.replyCount}}
+    {{#if (theme-setting 'show_reply_count')}}
+      <span class="topic-card__reply_count item">
+        {{d-icon "comment"}}
+        <span class="number">
+          {{view.topic.replyCount}}
+        </span>
       </span>
-    </span>
+    {{/if}}
 
-    {{raw "list/activity-column" topic=view.topic class="topic-card-data-activity item" tagName="div"}}
+    {{#if (theme-setting 'show_activity')}}
+      {{raw "list/activity-column" topic=view.topic class="topic-card-data-activity item" tagName="div"}}
+    {{/if}}
   </div>
 </div>

--- a/javascripts/discourse/templates/topic-metadata.hbr
+++ b/javascripts/discourse/templates/topic-metadata.hbr
@@ -4,8 +4,28 @@
     {{format-date view.topic.createdAt format="medium-with-ago"}}
   </span>
 
-  <span class="topic-card__likes">
-    <span class="topic-card__likes-number">{{view.topic.like_count}}</span>
-    {{d-icon "heart"}}
-  </span>
+  <div class="right-aligned item">
+    <span class="topic-card__views">
+      {{d-icon "eye"}}
+      <span class="number">
+        {{view.topic.views}}
+      </span>
+    </span>
+
+    <span class="topic-card__likes item">
+      {{d-icon "heart"}}
+      <span class="number">
+        {{view.topic.like_count}}
+      </span>
+    </span>
+
+    <span class="topic-card__reply_count item">
+      {{d-icon "comment"}}
+      <span class="number">
+        {{view.replyCount}}
+      </span>
+    </span>
+
+    {{raw "list/activity-column" topic=view.topic class="topic-card-data-activity item" tagName="div"}}
+  </div>
 </div>

--- a/javascripts/discourse/templates/topic-metadata.hbr
+++ b/javascripts/discourse/templates/topic-metadata.hbr
@@ -22,7 +22,7 @@
     <span class="topic-card__reply_count item">
       {{d-icon "comment"}}
       <span class="number">
-        {{view.replyCount}}
+        {{view.topic.replyCount}}
       </span>
     </span>
 

--- a/javascripts/discourse/templates/topic-metadata.hbr
+++ b/javascripts/discourse/templates/topic-metadata.hbr
@@ -6,9 +6,9 @@
     </span>
   {{/if}}
 
-  <div class="right-aligned item">
+  <div class="right-aligned">
     {{#if (theme-setting 'show_views')}}
-      <span class="topic-card__views">
+      <span class="topic-card__views item">
         {{d-icon "eye"}}
         <span class="number">
           {{view.topic.views}}

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,20 @@
+show_likes:
+  type: bool
+  default: true
+  description: Show likes on topic card
+show_views:
+  type: bool
+  default: false
+  description: Show views on topic card
+show_reply_count:
+  type: bool
+  default: false
+  description: Show reply count on topic card
+show_activity:
+  type: bool
+  default: false
+  description: Show activity on topic card
+show_publish_date:
+  type: bool
+  default: true
+  description: Show publish date on topic card


### PR DESCRIPTION
As discussed in https://meta.discourse.org/t/add-icons-for-views-and-replies-and-last-activity-date-in-topic-cards/312505 this PR adds icons for views, replies and last activity.