### PR TITLE
FEATURE: Show full name if available

### DIFF
--- a/javascripts/discourse/components/topic-op.gjs
+++ b/javascripts/discourse/components/topic-op.gjs
@@ -1,3 +1,4 @@
+import { and, not } from "truth-helpers";
 import UserLink from "discourse/components/user-link";
 import avatar from "discourse/helpers/avatar";
 
@@ -6,7 +7,16 @@ const TopicOp = <template>
     <UserLink @user={{@topic.creator}}>
       {{avatar @topic.creator imageSize="tiny"}}
       <span class="username">
-        {{@topic.creator.username}}
+        {{#if
+          (and
+            @topic.creator.name
+            (not this.siteSettings.prioritize_username_in_ux)
+          )
+        }}
+          {{@topic.creator.name}}
+        {{else}}
+          {{@topic.creator.username}}
+        {{/if}}
       </span>
     </UserLink>
   </div>


### PR DESCRIPTION
The username is very visible on the cards as only the op is shown. However, this leads to inconsistencies when the full name is otherwise prioritized on an instance. The PR adds a check and shows the full name in case.

![image](https://github.com/user-attachments/assets/fca4e1cb-a53e-48d3-a37c-fbb8ba8f8afe)