### PR TITLE
FIX: likes were broken

### DIFF
--- a/javascripts/discourse/components/like-toggle.gjs
+++ b/javascripts/discourse/components/like-toggle.gjs
@@ -21,7 +21,7 @@ export default class LikeToggle extends Component {
   clickCounter = 0;
 
   get firstPostId() {
-    return !!this.args.topic.first_post_id;
+    return this.args.topic.first_post_id || false;
   }
 
   @action
@@ -77,7 +77,7 @@ export default class LikeToggle extends Component {
     <button
       {{on "click" this.toggleLikeDebounced}}
       type="button"
-      disabled={{not this.canLike}}
+      disabled={{not @topic.op_can_like}}
       title={{if
         @topic.op_can_like
         (i18n (themePrefix "like_toggle.like"))


### PR DESCRIPTION
ad60c74a broke two things:
- it removed canLike but did not replace the calls everywhere
- it turned firstPostId() into a boolean