### PR TITLE
FIX: use topic-list cells from core

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -200,12 +200,6 @@
           display: flex;
           justify-content: space-between;
           align-items: center;
-
-          .item {
-            flex-grow: 0;
-            flex-shrink: 1;
-            margin-left: 20px; // Adjust as necessary for spacing
-          }
         }
 
         .topic__like-button {

--- a/common/common.scss
+++ b/common/common.scss
@@ -85,13 +85,16 @@
     tr {
       border-bottom: none;
     }
+
     td.num {
       padding: 0 0 0 20px;
+
       &.posts,
       &.views,
       &.activity {
         display: table-cell;
         width: auto;
+
         a {
           padding: 0;
         }

--- a/common/common.scss
+++ b/common/common.scss
@@ -82,6 +82,10 @@
   }
 
   .topic-card__stats {
+    tbody {
+      border: none;
+    }
+
     tr {
       border-bottom: none;
     }

--- a/common/common.scss
+++ b/common/common.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.topic-cards-icon {
+  display: none; // for non-topic-card views, suppress the icons injected via the topic-list-before-XXX-count outlets
+}
+
 // card
 .topic-card {
   display: flex;
@@ -36,6 +40,10 @@
   background-color: var(--secondary);
   box-shadow: var(--shadow-card);
   border: 1px solid transparent;
+
+  .topic-cards-icon {
+    display: inline-block;
+  }
 
   &:hover,
   &.selected {
@@ -71,6 +79,24 @@
   .posters,
   &__tags {
     display: none;
+  }
+
+  .topic-card__stats {
+    tr {
+      border-bottom: none;
+    }
+    td.num {
+      padding: 0 0 0 20px;
+      &.posts,
+      &.views,
+      &.activity {
+        display: table-cell;
+        width: auto;
+        a {
+          padding: 0;
+        }
+      }
+    }
   }
 
   // new elements styling

--- a/javascripts/discourse/components/topic-metadata.gjs
+++ b/javascripts/discourse/components/topic-metadata.gjs
@@ -1,5 +1,6 @@
 import ActivityCell from "discourse/components/topic-list/item/activity-cell";
-import dIcon from "discourse/helpers/d-icon";
+import RepliesCell from "discourse/components/topic-list/item/replies-cell";
+import ViewsCell from "discourse/components/topic-list/item/views-cell";
 import formatDate from "discourse/helpers/format-date";
 import { i18n } from "discourse-i18n";
 import LikeToggle from "./like-toggle";
@@ -14,35 +15,27 @@ const TopicMetadata = <template>
     {{/if}}
 
     <div class="right-aligned">
-      {{#if settings.show_views}}
-        <span class="topic-card__views item">
-          {{dIcon "eye"}}
-          <span class="number">
-            {{@topic.views}}
-          </span>
-        </span>
-      {{/if}}
+      <table class="topic-card__stats">
+        <tr>
+          {{#if settings.show_views}}
+            <ViewsCell @topic={{@topic}} />
+          {{/if}}
 
-      {{#if settings.show_likes}}
-        <span class="topic-card__likes item">
-          <LikeToggle @topic={{@topic}} />
-        </span>
-      {{/if}}
+          {{#if settings.show_likes}}
+            <td class="num topic-list-data topic-card__likes">
+              <LikeToggle @topic={{@topic}} />
+            </td>
+          {{/if}}
 
-      {{#if settings.show_reply_count}}
-        <span class="topic-card__reply_count item">
-          {{dIcon "comment"}}
-          <span class="number">
-            {{@topic.replyCount}}
-          </span>
-        </span>
-      {{/if}}
+          {{#if settings.show_reply_count}}
+            <RepliesCell @topic={{@topic}} />
+          {{/if}}
 
-      {{#if settings.show_activity}}
-        <div class="topic-card__activity item">
-          <ActivityCell @topic={{@topic}} />
-        </div>
-      {{/if}}
+          {{#if settings.show_activity}}
+            <ActivityCell @topic={{@topic}} />
+          {{/if}}
+        </tr>
+      </table>
     </div>
   </div>
 </template>;

--- a/javascripts/discourse/components/topic-metadata.gjs
+++ b/javascripts/discourse/components/topic-metadata.gjs
@@ -16,25 +16,27 @@ const TopicMetadata = <template>
 
     <div class="right-aligned">
       <table class="topic-card__stats">
-        <tr>
-          {{#if settings.show_views}}
-            <ViewsCell @topic={{@topic}} />
-          {{/if}}
+        <tbody>
+          <tr>
+            {{#if settings.show_views}}
+              <ViewsCell @topic={{@topic}} />
+            {{/if}}
 
-          {{#if settings.show_likes}}
-            <td class="num topic-list-data topic-card__likes">
-              <LikeToggle @topic={{@topic}} />
-            </td>
-          {{/if}}
+            {{#if settings.show_likes}}
+              <td class="num topic-list-data topic-card__likes">
+                <LikeToggle @topic={{@topic}} />
+              </td>
+            {{/if}}
 
-          {{#if settings.show_reply_count}}
-            <RepliesCell @topic={{@topic}} />
-          {{/if}}
+            {{#if settings.show_reply_count}}
+              <RepliesCell @topic={{@topic}} />
+            {{/if}}
 
-          {{#if settings.show_activity}}
-            <ActivityCell @topic={{@topic}} />
-          {{/if}}
-        </tr>
+            {{#if settings.show_activity}}
+              <ActivityCell @topic={{@topic}} />
+            {{/if}}
+          </tr>
+        </tbody>
       </table>
     </div>
   </div>

--- a/javascripts/discourse/connectors/topic-list-before-reply-count/replies-icon.gjs
+++ b/javascripts/discourse/connectors/topic-list-before-reply-count/replies-icon.gjs
@@ -1,0 +1,3 @@
+import dIcon from "discourse/helpers/d-icon";
+
+export default <template>{{dIcon "comment" class="topic-cards-icon"}}</template>

--- a/javascripts/discourse/connectors/topic-list-before-view-count/views-icon.gjs
+++ b/javascripts/discourse/connectors/topic-list-before-view-count/views-icon.gjs
@@ -1,0 +1,3 @@
+import dIcon from "discourse/helpers/d-icon";
+
+export default <template>{{dIcon "eye" class="topic-cards-icon"}}</template>


### PR DESCRIPTION
In 89d5674 the code was glimmerized and ActivityCell was introduced instead of the raw view. The raw view had a tagName="div" but ActivityCell and ViewsCell do not support that, they hard code a `<td>`. This resulted in invalid HTML.

To fix that issue, avoid copying code into this component and to leverage the A11Y from core, the views and replies have been replaced by ViewsCell and RepliesCell, and a table has been introduced to make the `<td>` valid.

We also introduce connectors to get the icons right and hide the icons using CSS on non-topic-card topic lists.