### PR TITLE
FEATURE: support prioritizing real names

### DIFF
--- a/javascripts/discourse/components/topic-op.gjs
+++ b/javascripts/discourse/components/topic-op.gjs
@@ -1,15 +1,27 @@
+import Component from "@glimmer/component";
 import UserLink from "discourse/components/user-link";
 import avatar from "discourse/helpers/avatar";
+import { prioritizeNameInUx } from "discourse/lib/settings";
 
-const TopicOp = <template>
-  <div class="topic-card__op">
-    <UserLink @user={{@topic.creator}}>
-      {{avatar @topic.creator imageSize="tiny"}}
-      <span class="username">
-        {{@topic.creator.username}}
-      </span>
-    </UserLink>
-  </div>
-</template>;
+export default class TopicOp extends Component {
+  get creatorName() {
+    const creator = this.args.topic.creator;
 
-export default TopicOp;
+    if (prioritizeNameInUx(creator?.name)) {
+      return creator.name;
+    }
+
+    return creator?.username;
+  }
+
+  <template>
+    <div class="topic-card__op">
+      <UserLink @user={{@topic.creator}}>
+        {{avatar @topic.creator imageSize="tiny"}}
+        <span class="username">
+          {{this.creatorName}}
+        </span>
+      </UserLink>
+    </div>
+  </template>
+}


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/topic-cards/296048/111?u=awesomerobot

This follows our core patterns for showing a user's real name (if available) when the site setting `Prioritize username in UX` is disabled 


Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/315c6215-9d91-46b0-9868-fa2054a61067" />


After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/dc2adb5a-0a0a-4c4a-900c-7dc69534539d" />
